### PR TITLE
Synchronization for capture_

### DIFF
--- a/generic/test-io/TestIO.hs
+++ b/generic/test-io/TestIO.hs
@@ -6,7 +6,7 @@ import Control.Monad
 import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import System.Exit
 import System.IO (Handle, IOMode (..), hFlush, stderr, stdin, withFile)
-import Prelude hiding (lines, putStrLn, unlines, writeFile, appendFile)
+import Prelude hiding (lines, putStrLn, unlines, writeFile)
 
 -- text
 import Data.Text


### PR DESCRIPTION
Partially Fixes #50 - Output is now captured via MVar. This does not solve the issue of running the test on fast HW in general.