### PR TITLE
Fix a typo in 2-count-the-words Koan and solution

### DIFF
--- a/koans/basic/2/2-count-the-words/Koan.hs
+++ b/koans/basic/2/2-count-the-words/Koan.hs
@@ -1,7 +1,7 @@
 {- | Count the words.
 
 With any clock, you can treat the 'Tag' like any other data.
-For example, you can apply any function the console input.
+For example, you can apply any function to the console input.
 -}
 module Koan where
 

--- a/koans/basic/2/2-count-the-words/solution/Koan.hs
+++ b/koans/basic/2/2-count-the-words/solution/Koan.hs
@@ -1,7 +1,7 @@
 {- | Count the words.
 
 With any clock, you can treat the 'Tag' like any other data.
-For example, you can apply any function the console input.
+For example, you can apply any function to the console input.
 -}
 module Koan where
 


### PR DESCRIPTION
@gregorias Sorry I didn't merge https://github.com/turion/rhine-koans/pull/45/ and https://github.com/turion/rhine-koans/pull/46/! I have a CI check in place that ensures that changes in solutions and koans have to be in the same PR, that's why the CI failed.