### PR TITLE
ci: make the success job a real required check (re-actors/alls-green)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,28 @@ jobs:
 
   success:
     name: All GHCs built successfully
-    runs-on: ubuntu-latest
+    # Every job defined above must be listed here: `success` is the one check
+    # required by branch protection, and it can only fail for a job that this
+    # list names. A bare `needs:` list is not enough either — GitHub *skips* a
+    # job whose dependency failed, and branch protection counts a skipped
+    # required check as passing, so the gate would go green on a red build.
+    # `if: always()` plus `alls-green` is what prevents that: the action's
+    # default policy accepts only `success` for every job handed to it.
+    # Do not change `always()` to `!cancelled()` — a cancelled dependency
+    # would then skip this job, and a skipped required check reports Success.
     needs:
+      - lint
+      - fourmolu
+      - generateMatrix
       - build-cabal
+      - generate-flake-ghc-matrix
       - build-flake
+      - presentation
+      - diffs
+    if: always()
+    runs-on: ubuntu-latest
     steps:
-      - name: Success
-        run: echo "Success"
+      - name: Fail if any dependency did not succeed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
`success` is the single required check for branch protection, but as written it
could report **green on a red build**. Two independent holes:

1. **No `if:`.** GitHub *skips* a job whose dependency failed, and branch
   protection counts a *skipped* required check as **passing**. The
   `echo "Success"` step was decorative: it could only ever run in the case
   where everything had already passed.
2. **Incomplete `needs:`.** Only `build-cabal` and `build-flake` were listed,
   so a failing `lint` or `fourmolu` could not turn the gate red even in
   principle.

This PR:

- adds `if: always()`, so the job runs whatever the dependencies did;
- hands the whole `needs` context to
  [`re-actors/alls-green`](https://github.com/re-actors/alls-green), whose
  default policy accepts only `success` for every job it is given
  (`allowed-failures` / `allowed-skips` opt individual jobs out — none are
  needed here, since no job in this workflow is conditionally skipped);
- names every other job in `needs:`.

The job's display name is unchanged, so **branch protection needs no
reconfiguration**.

Background: [community discussion #26733](https://github.com/orgs/community/discussions/26733).

Not addressed here: the `needs:` list is still hand-maintained, so a job added
later is silently ungated again. `gravensteiner` asserts completeness with a
`nix flake check` check that diffs `jobs | keys` against `success.needs` with
`yq`; happy to port that too if you want it.
